### PR TITLE
Fix/display name on results

### DIFF
--- a/src/components/SimulationResults.tsx
+++ b/src/components/SimulationResults.tsx
@@ -13,10 +13,10 @@ const SimulationResult = () => {
         <thead>
           <tr>
             <th>Round</th>
-            <th>Strategy 1 Move</th>
-            <th>Strategy 2 Move</th>
-            <th>Strategy 1 Points</th>
-            <th>Strategy 2 Points</th>
+            <th>{results.strategy1} Move</th>
+            <th>{results.strategy2} Move</th>
+            <th>{results.strategy1} Points</th>
+            <th>{results.strategy2} Points</th>
           </tr>
         </thead>
         <tbody>
@@ -32,8 +32,12 @@ const SimulationResult = () => {
         </tbody>
       </table>
       <h3>Final Score</h3>
-      <p>Strategy 1: {results.finalScore.strategy1}</p>
-      <p>Strategy 2: {results.finalScore.strategy2}</p>
+      <p>
+        {results.strategy1}: {results.finalScore.strategy1}
+      </p>
+      <p>
+        {results.strategy2}: {results.finalScore.strategy2}
+      </p>
     </div>
   );
 };

--- a/src/utils/simulation.ts
+++ b/src/utils/simulation.ts
@@ -11,6 +11,8 @@ export interface RoundResult {
 }
 
 export interface PlayResult {
+  strategy1: StrategyName;
+  strategy2: StrategyName;
   rounds: RoundResult[];
   finalScore: {
     strategy1: number;
@@ -83,6 +85,8 @@ export const simulatePlay = (
   }
 
   return {
+    strategy1: strategy1Name,
+    strategy2: strategy2Name,
     rounds: roundResults,
     finalScore: {
       strategy1: strategy1TotalPoints,


### PR DESCRIPTION
# Show strategy name on results

A fix on the StrategyResults component, where instead of showing Strategy 1 Move, Strategy 1 Points, etc t shows the actual name of the strategy, like: Always Defect Move, Always Defect Points, etc

It uses the StrategyName type, to make sure the shown name is one of a valid strategy