### PR TITLE
Feature/graaskamp strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple web page that lets you test different strategies against each other on 
 - Davis: Cooperates the first 10 moves, then plays as Friedman
 - Feld: Similar to Tit 4 Tat, but the cooperation probability decreases linearly, until the last round, with a cooperation probability of 50%
 - Friedman: Cooperates until the opponent defects once, then always defects
+- Graaskamp: Plays Tit 4 Tat the first 50 moves, defects on 51 and plays Tit 4 Tat until round 56, afterwards it checks if the opponent is random, if so, it always defects, it checks if the opponent is Tit 4 Tat or a clone, if so, it plays Tit 4 Tat, if not, always cooperates, with a random defection every 5 to 15 moves
 - Grofman: Cooperates if the strategy and the opponent made the same move in the last turn, and if not, has a 28% of cooperating
 - Joss: Similar to Tit 4 Tat, but it has a 90% chance of betrayal when the opponent cooperated on the last move
 - Name withheld: Generates a random probability between 30% and 100% following a normal distribution, and makes a random choice with the generated probability
@@ -18,7 +19,6 @@ A simple web page that lets you test different strategies against each other on 
 
 # Not implemented strategies
 - Downing
-- Graaskamp
 - Nyedegger
 - Shubik
 - Tideman & Chieruzzi

--- a/src/strategies/Graaskamp.ts
+++ b/src/strategies/Graaskamp.ts
@@ -30,15 +30,17 @@ class Graaskamp extends StrategyChi2TestWithRounds {
     if (this.isOpponentRandom) {
       return this.setLastOwnMove(false);
     }
-
-    const playsTitForTat = this.ownMoveHistory
+    const isOpponentTitForTat = this.opponentMoveHistory
       .slice(1)
-      .every((move, index) => move === this.opponentMoveHistory[index]);
+      .every(
+        (opponentMove, index) => opponentMove === this.ownMoveHistory[index]
+      );
+
     const isClone = this.ownMoveHistory.every(
       (move, index) => move === this.opponentMoveHistory[index]
     );
 
-    if (playsTitForTat || isClone) {
+    if (isOpponentTitForTat || isClone) {
       if (!this.opponentMoveHistory.at(-1)) {
         return this.setLastOwnMove(false);
       }

--- a/src/strategies/Graaskamp.ts
+++ b/src/strategies/Graaskamp.ts
@@ -1,0 +1,10 @@
+import { StrategyChi2Test } from "./Strategy";
+import { Move } from "./types";
+
+class Graaskamp extends StrategyChi2Test {
+  getNextMove(): Move {}
+
+  setOpponentMove(move: Move): void {}
+}
+
+export default Graaskamp;

--- a/src/strategies/Graaskamp.ts
+++ b/src/strategies/Graaskamp.ts
@@ -1,7 +1,7 @@
-import { StrategyChi2Test } from "./Strategy";
+import { StrategyChi2TestWithRounds } from "./Strategy";
 import { Move } from "./types";
 
-class Graaskamp extends StrategyChi2Test {
+class Graaskamp extends StrategyChi2TestWithRounds {
   getNextMove(): Move {}
 
   setOpponentMove(move: Move): void {}

--- a/src/strategies/Graaskamp.ts
+++ b/src/strategies/Graaskamp.ts
@@ -18,8 +18,8 @@ class Graaskamp extends StrategyChi2TestWithRounds {
       return this.setLastOwnMove(true);
     }
 
-    if (this.currentRound < 10) {
-      if (!this.opponentMoveHistory.at(-1) || this.currentRound === 8) {
+    if (this.currentRound < 56) {
+      if (!this.opponentMoveHistory.at(-1) || this.currentRound === 50) {
         return this.setLastOwnMove(false);
       }
       return this.setLastOwnMove(true);

--- a/src/strategies/Graaskamp.ts
+++ b/src/strategies/Graaskamp.ts
@@ -1,10 +1,70 @@
+import { random_uniform } from "../utils/random";
 import { StrategyChi2TestWithRounds } from "./Strategy";
 import { Move } from "./types";
 
 class Graaskamp extends StrategyChi2TestWithRounds {
-  getNextMove(): Move {}
+  private isOpponentRandom: boolean = false;
+  private ownMoveHistory: Move[] = [];
+  private opponentMoveHistory: Move[] = [];
+  private nextRandomDefectionTurn: number | null = null;
 
-  setOpponentMove(move: Move): void {}
+  private setLastOwnMove(move: Move): Move {
+    this.ownMoveHistory.push(move);
+    return move;
+  }
+
+  getNextMove(): Move {
+    if (this.currentRound === 0) {
+      return this.setLastOwnMove(true);
+    }
+
+    if (this.currentRound < 10) {
+      if (!this.opponentMoveHistory.at(-1) || this.currentRound === 8) {
+        return this.setLastOwnMove(false);
+      }
+      return this.setLastOwnMove(true);
+    }
+    const { isRandom } = this.chi2test();
+    this.isOpponentRandom = this.isOpponentRandom || isRandom;
+
+    if (this.isOpponentRandom) {
+      return this.setLastOwnMove(false);
+    }
+
+    const playsTitForTat = this.ownMoveHistory
+      .slice(1)
+      .every((move, index) => move === this.opponentMoveHistory[index]);
+    const isClone = this.ownMoveHistory.every(
+      (move, index) => move === this.opponentMoveHistory[index]
+    );
+
+    if (playsTitForTat || isClone) {
+      if (!this.opponentMoveHistory.at(-1)) {
+        return this.setLastOwnMove(false);
+      }
+      return this.setLastOwnMove(true);
+    }
+
+    if (this.nextRandomDefectionTurn === null) {
+      this.nextRandomDefectionTurn =
+        Math.round(random_uniform(5, 15)) + this.currentRound;
+    }
+
+    if (this.currentRound === this.nextRandomDefectionTurn) {
+      // Resample the next defection turn
+      this.nextRandomDefectionTurn =
+        Math.round(random_uniform(5, 15)) + this.currentRound;
+      return this.setLastOwnMove(false); // Defect
+    }
+
+    return this.setLastOwnMove(true); // Cooperate
+  }
+
+  setOpponentMove(move: Move): void {
+    this.addMove(move);
+    this.opponentMoveHistory.push(move);
+    this.currentRound++;
+  }
 }
 
 export default Graaskamp;

--- a/src/strategies/Strategy.ts
+++ b/src/strategies/Strategy.ts
@@ -52,7 +52,20 @@ export class StrategyChi2Test extends StrategyBase {
   }
 }
 
-export type Strategy = StrategyBase | StrategyWithRounds | StrategyChi2Test;
+export class StrategyChi2TestWithRounds extends StrategyChi2Test {
+  protected rounds: number;
+
+  constructor(rounds: number) {
+    super();
+    this.rounds = rounds;
+  }
+}
+
+export type Strategy =
+  | StrategyBase
+  | StrategyWithRounds
+  | StrategyChi2Test
+  | StrategyChi2TestWithRounds;
 
 export type StrategyBaseConstructor = new () => Strategy;
 export type StrategyWithRoundsConstructor = new (rounds: number) => Strategy;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -16,6 +16,7 @@ import Grofman from "./Grofman";
 import Feld from "./Feld";
 import Anonymous from "./Anonymous";
 import SteinAndRapaport from "./SteinAndRapaport";
+import Graaskamp from "./Graaskamp";
 
 export type StrategyClassMap = {
   [key: string]: StrategyConstructor;
@@ -27,6 +28,7 @@ const strategyClassesConst = {
   Davis,
   Feld,
   Friedman,
+  Graaskamp,
   Grofman,
   Joss,
   "Name Witheld": Anonymous,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable",
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
# Add Graaskamp strategy

The strategy is implemented as
- Plays Tit 4 Tat the first 50 rounds
- Defects on 51
- Plays Tit 4 Tat until round 56
- Checks if the opponent is playing randomly
  - If so, it always defects
- Checks if the opponent is Tit 4 Tat or Graaskamp (a clone of itself)
  - If so, it plays Tit 4 Tat, 
- Always cooperates, with a random defection every 5 to 15 moves