### PR TITLE
Feature/tullock strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A simple web page that lets you test different strategies against each other on 
 - Stein & rapoport: Cooperates the first 5 moves, play Tit 4 Tat the next 10 moves, after this, it will check if the other player is playing randomly, if true, always defects, if not, it plays Tit 4 Tat. Will repeat the randomness check every 15 moves
 - Random: Cooperates or defects randomly
 - Tit 4 Tat: Imitates the movement the other strategy did in the last move
+- Tullock: Cooperates the first 11 moves, then randonmy cooperates, with a probability 10% less than his opponent on the alst 10 moves
 
 # Not implemented strategies
 - Downing
 - Nyedegger
 - Shubik
 - Tideman & Chieruzzi
-- Tullock

--- a/src/strategies/Tullock.ts
+++ b/src/strategies/Tullock.ts
@@ -1,0 +1,12 @@
+import { StrategyBase } from "./Strategy";
+import { Move } from "./types";
+
+class Tullock extends StrategyBase {
+  private roundsToCooperate: number = 11;
+  private opponentMoveHistory: Move[] = [];
+  private currentRound: number = 0;
+
+  getNextMove(): Move {}
+
+  setOpponentMove(move: Move): void {}
+}

--- a/src/strategies/Tullock.ts
+++ b/src/strategies/Tullock.ts
@@ -8,5 +8,8 @@ class Tullock extends StrategyBase {
 
   getNextMove(): Move {}
 
-  setOpponentMove(move: Move): void {}
+  setOpponentMove(move: Move): void {
+    this.opponentMoveHistory.push(move);
+    this.currentRound++;
+  }
 }

--- a/src/strategies/Tullock.ts
+++ b/src/strategies/Tullock.ts
@@ -1,3 +1,4 @@
+import { random_move_with_prob } from "../utils/random";
 import { StrategyBase } from "./Strategy";
 import { Move } from "./types";
 
@@ -6,7 +7,17 @@ class Tullock extends StrategyBase {
   private opponentMoveHistory: Move[] = [];
   private currentRound: number = 0;
 
-  getNextMove(): Move {}
+  getNextMove(): Move {
+    if (this.currentRound < this.roundsToCooperate) {
+      return true;
+    }
+    const rounds = this.roundsToCooperate--;
+    const cooperateCount = this.opponentMoveHistory
+      .slice(-rounds)
+      .filter((move) => move).length;
+    const prob_cooperate = Math.max(0, cooperateCount / rounds - 0.1);
+    return random_move_with_prob(prob_cooperate);
+  }
 
   setOpponentMove(move: Move): void {
     this.opponentMoveHistory.push(move);

--- a/src/strategies/Tullock.ts
+++ b/src/strategies/Tullock.ts
@@ -11,11 +11,11 @@ class Tullock extends StrategyBase {
     if (this.currentRound < this.roundsToCooperate) {
       return true;
     }
-    const rounds = this.roundsToCooperate--;
+    const recentMoves = this.roundsToCooperate - 1;
     const cooperateCount = this.opponentMoveHistory
-      .slice(-rounds)
+      .slice(-recentMoves)
       .filter((move) => move).length;
-    const prob_cooperate = Math.max(0, cooperateCount / rounds - 0.1);
+    const prob_cooperate = Math.max(0, cooperateCount / recentMoves - 0.1);
     return random_move_with_prob(prob_cooperate);
   }
 
@@ -24,3 +24,5 @@ class Tullock extends StrategyBase {
     this.currentRound++;
   }
 }
+
+export default Tullock;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -18,6 +18,7 @@ import Anonymous from "./Anonymous";
 import SteinAndRapaport from "./SteinAndRapaport";
 import Graaskamp from "./Graaskamp";
 import Shubik from "./Shubik";
+import Tullock from "./Tullock";
 
 export type StrategyClassMap = {
   [key: string]: StrategyConstructor;
@@ -37,6 +38,7 @@ const strategyClassesConst = {
   Shubik,
   "Stein and Rapaport": SteinAndRapaport,
   "Tit for Tat": TitForTat,
+  Tullock,
 } as const;
 
 export type StrategyName = keyof typeof strategyClassesConst;


### PR DESCRIPTION
# Add Tullock strategy

Add Tullock strategy to strategy list. It is implemented as: Cooperates for the first 11 moves, then cooperates randomly, with a cooperation probability of 10% less than the cooperation percentage of his opponent in the last 10 moves