### PR TITLE
Feature/Downing_strategy

### DIFF
--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -14,5 +14,8 @@ class Downing extends StrategyWithHistory {
 
   getNextMove(): Move {}
 
-  setOpponentMove(move: Move): void {}
+  setOpponentMove(move: Move): void {
+    this.setLastOpponentMove(move);
+    this.currentRound++;
+  }
 }

--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -68,3 +68,5 @@ class Downing extends StrategyWithHistory {
     this.currentRound++;
   }
 }
+
+export default Downing;

--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -7,12 +7,21 @@ class Downing extends StrategyWithHistory {
   private ownCooperations: number = 0;
   private ownDefections: number = 0;
 
-  private mutualDefectionPoints = 1;
-  private mutualCooperationPoints = 3;
-  private cooperationOnDefectionPoints = 0;
-  private defectionOnCooperationPoints = 5;
+  private MUTUAL_DEFECTION_POINTS = 1;
+  private MUTUAL_COOPERATION_POINTS = 3;
+  private COOPERATION_ON_DEFECTION_POINTS = 0;
+  private DEFECTION_ON_COOPERATION_POINTS = 5;
 
   getNextMove(): Move {}
+
+  protected setLastOwnMove(move: Move): Move {
+    this.ownMoveHistory.push(move);
+    if (move) {
+      this.ownCooperations++;
+    }
+    this.ownDefections++;
+    return move;
+  }
 
   setOpponentMove(move: Move): void {
     this.setLastOpponentMove(move);

--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -7,10 +7,10 @@ class Downing extends StrategyWithHistory {
   private ownCooperations: number = 0;
   private ownDefections: number = 0;
 
-  private MUTUAL_DEFECTION_POINTS = 1;
-  private MUTUAL_COOPERATION_POINTS = 3;
-  private COOPERATION_ON_DEFECTION_POINTS = 0;
-  private DEFECTION_ON_COOPERATION_POINTS = 5;
+  private R_MUTUAL_COOPERATION_POINTS = 3;
+  private P_MUTUAL_DEFECTION_POINTS = 1;
+  private S_COOPERATION_ON_DEFECTION_POINTS = 0;
+  private T_DEFECTION_ON_COOPERATION_POINTS = 5;
 
   getNextMove(): Move {}
 

--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -12,7 +12,47 @@ class Downing extends StrategyWithHistory {
   private S_COOPERATION_ON_DEFECTION_POINTS = 0;
   private T_DEFECTION_ON_COOPERATION_POINTS = 5;
 
-  getNextMove(): Move {}
+  getNextMove(): Move {
+    if (this.currentRound == 0) {
+      return this.setLastOwnMove(false);
+    }
+
+    if (this.currentRound == 1) {
+      if (this.opponentMoveHistory.at(-1)) {
+        this.opponentCooperationsInResponseToCooperation++;
+      }
+      return this.setLastOwnMove(false);
+    }
+
+    if (this.ownMoveHistory.at(-2) && this.opponentMoveHistory.at(-1)) {
+      this.opponentCooperationsInResponseToCooperation++;
+    }
+
+    if (!this.ownMoveHistory.at(-2) && this.opponentMoveHistory.at(-1)) {
+      this.opponentCooperationsInResponseToDefection++;
+    }
+
+    const alpha =
+      this.opponentCooperationsInResponseToCooperation /
+      (this.ownCooperations + 1);
+    const beta =
+      this.opponentCooperationsInResponseToDefection / this.ownDefections;
+
+    const expected_value_of_cooperating =
+      alpha * this.R_MUTUAL_COOPERATION_POINTS +
+      (1 - alpha) * this.S_COOPERATION_ON_DEFECTION_POINTS;
+    const expected_value_of_defecting =
+      beta * this.T_DEFECTION_ON_COOPERATION_POINTS +
+      (1 - beta) * this.P_MUTUAL_DEFECTION_POINTS;
+
+    if (expected_value_of_cooperating > expected_value_of_defecting) {
+      return this.setLastOwnMove(true);
+    }
+    if (expected_value_of_defecting < expected_value_of_cooperating) {
+      return this.setLastOwnMove(false);
+    }
+    return this.setLastOwnMove(!this.ownMoveHistory.at(-1));
+  }
 
   protected setLastOwnMove(move: Move): Move {
     this.ownMoveHistory.push(move);

--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -36,7 +36,8 @@ class Downing extends StrategyWithHistory {
       this.opponentCooperationsInResponseToCooperation /
       (this.ownCooperations + 1);
     const beta =
-      this.opponentCooperationsInResponseToDefection / this.ownDefections;
+      this.opponentCooperationsInResponseToDefection /
+      Math.max(this.ownDefections, 2);
 
     const expected_value_of_cooperating =
       alpha * this.R_MUTUAL_COOPERATION_POINTS +
@@ -48,7 +49,7 @@ class Downing extends StrategyWithHistory {
     if (expected_value_of_cooperating > expected_value_of_defecting) {
       return this.setLastOwnMove(true);
     }
-    if (expected_value_of_defecting < expected_value_of_cooperating) {
+    if (expected_value_of_defecting > expected_value_of_cooperating) {
       return this.setLastOwnMove(false);
     }
     return this.setLastOwnMove(!this.ownMoveHistory.at(-1));
@@ -58,8 +59,9 @@ class Downing extends StrategyWithHistory {
     this.ownMoveHistory.push(move);
     if (move) {
       this.ownCooperations++;
+    } else {
+      this.ownDefections++;
     }
-    this.ownDefections++;
     return move;
   }
 

--- a/src/strategies/Downing.ts
+++ b/src/strategies/Downing.ts
@@ -1,0 +1,18 @@
+import { StrategyWithHistory } from "./Strategy";
+import { Move } from "./types";
+
+class Downing extends StrategyWithHistory {
+  private opponentCooperationsInResponseToCooperation: number = 0;
+  private opponentCooperationsInResponseToDefection: number = 0;
+  private ownCooperations: number = 0;
+  private ownDefections: number = 0;
+
+  private mutualDefectionPoints = 1;
+  private mutualCooperationPoints = 3;
+  private cooperationOnDefectionPoints = 0;
+  private defectionOnCooperationPoints = 5;
+
+  getNextMove(): Move {}
+
+  setOpponentMove(move: Move): void {}
+}

--- a/src/strategies/Strategy.ts
+++ b/src/strategies/Strategy.ts
@@ -61,11 +61,36 @@ export class StrategyChi2TestWithRounds extends StrategyChi2Test {
   }
 }
 
+export class StrategyWithHistory extends StrategyWithRounds {
+  protected ownMoveHistory: Move[] = [];
+  protected opponentMoveHistory: Move[] = [];
+  protected currentRound: number = 0;
+
+  protected setLastOwnMove(move: Move): Move {
+    this.ownMoveHistory.push(move);
+    return move;
+  }
+
+  protected setLastOpponentMove(move: Move): void {
+    this.opponentMoveHistory.push(move);
+  }
+
+  getNextMove(): Move {
+    throw new Error("getNextMove must be implemented");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setOpponentMove(_move: Move): void {
+    throw new Error("setOpponentMove must be implemented");
+  }
+}
+
 export type Strategy =
   | StrategyBase
   | StrategyWithRounds
   | StrategyChi2Test
-  | StrategyChi2TestWithRounds;
+  | StrategyChi2TestWithRounds
+  | StrategyWithHistory;
 
 export type StrategyBaseConstructor = new () => Strategy;
 export type StrategyWithRoundsConstructor = new (rounds: number) => Strategy;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -19,6 +19,7 @@ import SteinAndRapaport from "./SteinAndRapaport";
 import Graaskamp from "./Graaskamp";
 import Shubik from "./Shubik";
 import Tullock from "./Tullock";
+import Downing from "./Downing";
 
 export type StrategyClassMap = {
   [key: string]: StrategyConstructor;
@@ -28,6 +29,7 @@ const strategyClassesConst = {
   "Always Cooperate": AlwaysCooperate,
   "Always Defect": AlwaysDefect,
   Davis,
+  Downing,
   Feld,
   Friedman,
   Graaskamp,


### PR DESCRIPTION
# Add Downing strategy
Add Downing strategy to strategy list, it is implemented as:
- In each turn, keeps track of the cooperations made by the opponent in response to a cooperation or defection
- Defects the first 2 rounds
- Calculates the expected points it could gain from cooperating or defecting in the next move
- Based on this, the strategy cooperates or defects
  - If the gain from cooperating is greater, it cooperates
  - If the gain from defecting is greater, it defects
  - If both are equal, it returns the opposite of its last own move
