### PR TITLE
Feature/nydegger strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A simple web page that lets you test different strategies against each other on 
 - Grofman: Cooperates if the strategy and the opponent made the same move in the last turn, and if not, has a 28% of cooperating
 - Joss: Similar to Tit 4 Tat, but it has a 90% chance of betrayal when the opponent cooperated on the last move
 - Name withheld: Generates a random probability between 30% and 100% following a normal distribution, and makes a random choice with the generated probability
+- Nyedegger: Tries to maximize its own points, making a choice based on his own and the opponent last 3 moves, giving them a score and defecting depending on the score given
 - Shubik: The player cooperates, until the opponent betrays them, then it defect for n moves, and starts cooperating again, if betrayed again, it defects for n + 1 moves
 - Stein & rapoport: Cooperates the first 5 moves, play Tit 4 Tat the next 10 moves, after this, it will check if the other player is playing randomly, if true, always defects, if not, it plays Tit 4 Tat. Will repeat the randomness check every 15 moves
 - Random: Cooperates or defects randomly
@@ -21,5 +22,4 @@ A simple web page that lets you test different strategies against each other on 
 - Tullock: Cooperates the first 11 moves, then randonmy cooperates, with a probability 10% less than his opponent on the alst 10 moves
 
 # Not implemented strategies
-- Nyedegger
 - Tideman & Chieruzzi

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -1,0 +1,10 @@
+import { StrategyWithHistory } from "./Strategy";
+import { Move } from "./types";
+
+class Nydegger extends StrategyWithHistory {
+  getNextMove(): Move {}
+
+  setOpponentMove(move: Move): void {}
+}
+
+export default Nydegger;

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -17,6 +17,23 @@ class Nydegger extends StrategyWithHistory {
     return this.scoreMap.get([ownMove, opponentMove])!;
   }
 
+  private getScore(): number {
+    const [lastOwnMove, secondLastOwnMove, thirdLastOwnMove] =
+      this.ownMoveHistory.slice(-3);
+    const [lastOpponentMove, secondLastOpponentMove, thirdLastOpponentMove] =
+      this.opponentMoveHistory.slice(-3);
+
+    const lastScore = this.getScorePerMove(lastOwnMove, lastOpponentMove) * 16;
+    const secondLastScore =
+      this.getScorePerMove(secondLastOwnMove, secondLastOpponentMove) * 4;
+    const thirdLastScore = this.getScorePerMove(
+      thirdLastOwnMove,
+      thirdLastOpponentMove
+    );
+
+    return lastScore + secondLastScore + thirdLastScore;
+  }
+
   getNextMove(): Move {}
 
   setOpponentMove(move: Move): void {

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -4,7 +4,10 @@ import { Move } from "./types";
 class Nydegger extends StrategyWithHistory {
   getNextMove(): Move {}
 
-  setOpponentMove(move: Move): void {}
+  setOpponentMove(move: Move): void {
+    this.setLastOpponentMove(move);
+    this.currentRound++;
+  }
 }
 
 export default Nydegger;

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -40,14 +40,14 @@ class Nydegger extends StrategyWithHistory {
     }
 
     if (this.currentRound == 1) {
-      const lastOpponentMove = !this.opponentMoveHistory.at(-1);
+      const lastOpponentMove = this.opponentMoveHistory.at(-1)!;
       return this.setLastOwnMove(lastOpponentMove);
     }
     if (this.currentRound == 2) {
       if (!this.opponentMoveHistory.at(-2) && this.opponentMoveHistory.at(-1)) {
         return this.setLastOwnMove(false);
       }
-      const lastOpponentMove = !this.opponentMoveHistory.at(-1);
+      const lastOpponentMove = this.opponentMoveHistory.at(-1)!;
       return this.setLastOwnMove(lastOpponentMove);
     }
 

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -34,7 +34,29 @@ class Nydegger extends StrategyWithHistory {
     return lastScore + secondLastScore + thirdLastScore;
   }
 
-  getNextMove(): Move {}
+  getNextMove(): Move {
+    if (this.currentRound == 0) {
+      return this.setLastOwnMove(true);
+    }
+
+    if (this.currentRound == 1) {
+      const lastOpponentMove = !this.opponentMoveHistory.at(-1);
+      return this.setLastOwnMove(lastOpponentMove);
+    }
+    if (this.currentRound == 2) {
+      if (!this.opponentMoveHistory.at(-2) && this.opponentMoveHistory.at(-1)) {
+        return this.setLastOwnMove(false);
+      }
+      const lastOpponentMove = !this.opponentMoveHistory.at(-1);
+      return this.setLastOwnMove(lastOpponentMove);
+    }
+
+    const score = this.getScore();
+    if (this.pointsToDefect.includes(score)) {
+      return this.setLastOwnMove(false);
+    }
+    return this.setLastOwnMove(true);
+  }
 
   setOpponentMove(move: Move): void {
     this.setLastOpponentMove(move);

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -13,6 +13,10 @@ class Nydegger extends StrategyWithHistory {
     [[false, false], 3],
   ]);
 
+  private getScorePerMove(ownMove: Move, opponentMove: Move): number {
+    return this.scoreMap.get([ownMove, opponentMove])!;
+  }
+
   getNextMove(): Move {}
 
   setOpponentMove(move: Move): void {

--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -2,6 +2,17 @@ import { StrategyWithHistory } from "./Strategy";
 import { Move } from "./types";
 
 class Nydegger extends StrategyWithHistory {
+  private pointsToDefect: number[] = [
+    1, 6, 7, 17, 22, 23, 26, 29, 30, 31, 33, 38, 39, 45, 49, 54, 55, 58, 61,
+  ];
+
+  private scoreMap = new Map<[boolean, boolean], number>([
+    [[true, true], 0],
+    [[true, false], 2],
+    [[false, true], 1],
+    [[false, false], 3],
+  ]);
+
   getNextMove(): Move {}
 
   setOpponentMove(move: Move): void {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -20,6 +20,7 @@ import Graaskamp from "./Graaskamp";
 import Shubik from "./Shubik";
 import Tullock from "./Tullock";
 import Downing from "./Downing";
+import Nydegger from "./Nydegger";
 
 export type StrategyClassMap = {
   [key: string]: StrategyConstructor;
@@ -36,6 +37,7 @@ const strategyClassesConst = {
   Grofman,
   Joss,
   "Name Witheld": Anonymous,
+  Nydegger,
   Random: RandomStrategy,
   Shubik,
   "Stein and Rapaport": SteinAndRapaport,


### PR DESCRIPTION
# Add Nydegger strategy
Add Nydegger strategy to strategy list, is implemented as:
- Plays Tit for Tat for the first 3 moves
  - Except if it cooperated on the first move and defected on the second, then it will defect on the third move
- It then assigns a score based on the last 3 moves
  - It does this by first give a score to each move based in the combination of his move and the opponent move
  - Then it weights them, depending on if it was the first, second or third last move
  - Adds the scores
- If the score is in the given list, it will defect, otherwise it will cooperate