### PR TITLE
Fix Nydegger strategy scoreMap

### DIFF
--- a/src/strategies/Nydegger.ts
+++ b/src/strategies/Nydegger.ts
@@ -6,15 +6,15 @@ class Nydegger extends StrategyWithHistory {
     1, 6, 7, 17, 22, 23, 26, 29, 30, 31, 33, 38, 39, 45, 49, 54, 55, 58, 61,
   ];
 
-  private scoreMap = new Map<[boolean, boolean], number>([
-    [[true, true], 0],
-    [[true, false], 2],
-    [[false, true], 1],
-    [[false, false], 3],
+  private scoreMap = new Map<string, number>([
+    ["true,true", 0],
+    ["true,false", 2],
+    ["false,true", 1],
+    ["false,false", 3],
   ]);
 
   private getScorePerMove(ownMove: Move, opponentMove: Move): number {
-    return this.scoreMap.get([ownMove, opponentMove])!;
+    return this.scoreMap.get(`${ownMove},${opponentMove}`)!;
   }
 
   private getScore(): number {


### PR DESCRIPTION
# Fix Nydegger strategy scoreMap

Because of JavaScript Symbol limitations, the key on a Map should not be a [boolean, boolean], since it treats it as a unique reference, hence, the [boolean, boolean] from the Map, would not be the same as that from the Map.get method, and always fail