### PR TITLE
Feature/results table styles

### DIFF
--- a/src/components/SimulationResults.tsx
+++ b/src/components/SimulationResults.tsx
@@ -1,3 +1,4 @@
+import { Container, Table, TableData } from "@mantine/core";
 import { useSimulation } from "../hooks/useSimulation";
 
 const SimulationResult = () => {
@@ -6,31 +7,41 @@ const SimulationResult = () => {
     return <p>No results to display</p>;
   }
 
+  const tableData: TableData = {
+    head: [
+      "Round",
+      `${results.strategy1} Move`,
+      `${results.strategy1} Points`,
+      `${results.strategy2} Move`,
+      `${results.strategy2} Points`,
+    ],
+    body: results.rounds.map((round) => [
+      round.round,
+      round.strategy1Move ? "Cooperate" : "Defect",
+      round.strategy2Move ? "Cooperate" : "Defect",
+      round.strategy1Points,
+      round.strategy2Points,
+    ]),
+  };
+
   return (
-    <div>
+    <div className="">
       <h2>Simulation Results</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Round</th>
-            <th>{results.strategy1} Move</th>
-            <th>{results.strategy2} Move</th>
-            <th>{results.strategy1} Points</th>
-            <th>{results.strategy2} Points</th>
-          </tr>
-        </thead>
-        <tbody>
-          {results.rounds.map((round) => (
-            <tr key={round.round}>
-              <td>{round.round}</td>
-              <td>{round.strategy1Move ? "Cooperate" : "Defect"}</td>
-              <td>{round.strategy2Move ? "Cooperate" : "Defect"}</td>
-              <td>{round.strategy1Points}</td>
-              <td>{round.strategy2Points}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <Container>
+        <Table
+          striped="even"
+          data={tableData}
+          stickyHeader
+          withColumnBorders
+          withRowBorders={false}
+          withTableBorder
+          classNames={{
+            th: "text-center",
+            td: "text-center",
+            thead: "bg-[--table-striped-color]",
+          }}
+        />
+      </Container>
       <h3>Final Score</h3>
       <p>
         {results.strategy1}: {results.finalScore.strategy1}

--- a/src/components/SimulationResults.tsx
+++ b/src/components/SimulationResults.tsx
@@ -4,7 +4,13 @@ import { useSimulation } from "../hooks/useSimulation";
 const SimulationResult = () => {
   const { results } = useSimulation();
   if (results === null) {
-    return <p>No results to display</p>;
+    return (
+      <Container>
+        <Text mt={4} ta="center">
+          No results to display
+        </Text>
+      </Container>
+    );
   }
 
   const tableData: TableData = {

--- a/src/components/SimulationResults.tsx
+++ b/src/components/SimulationResults.tsx
@@ -1,8 +1,23 @@
-import { Container, Table, TableData } from "@mantine/core";
+import {
+  Button,
+  Center,
+  Collapse,
+  Container,
+  Table,
+  TableData,
+  Text,
+  Title,
+} from "@mantine/core";
 import { useSimulation } from "../hooks/useSimulation";
+import { useDisclosure } from "@mantine/hooks";
+import { useEffect } from "react";
 
 const SimulationResult = () => {
   const { results } = useSimulation();
+  const [showResultsTable, { toggle, close }] = useDisclosure(false);
+  useEffect(() => {
+    close();
+  }, [results]);
   if (results === null) {
     return (
       <Container>
@@ -31,9 +46,19 @@ const SimulationResult = () => {
   };
 
   return (
-    <div className="">
-      <h2>Simulation Results</h2>
-      <Container>
+    <Container>
+      <Title>Simulation Results</Title>
+      <h3>Final Score</h3>
+      <p>
+        {results.strategy1}: {results.finalScore.strategy1}
+      </p>
+      <p>
+        {results.strategy2}: {results.finalScore.strategy2}
+      </p>
+      <Center className="mb-2">
+        <Button onClick={toggle}>Show rounds</Button>
+      </Center>
+      <Collapse in={showResultsTable} transitionDuration={500} className="mb-4">
         <Table
           striped="even"
           data={tableData}
@@ -47,15 +72,8 @@ const SimulationResult = () => {
             thead: "bg-[--table-striped-color]",
           }}
         />
-      </Container>
-      <h3>Final Score</h3>
-      <p>
-        {results.strategy1}: {results.finalScore.strategy1}
-      </p>
-      <p>
-        {results.strategy2}: {results.finalScore.strategy2}
-      </p>
-    </div>
+      </Collapse>
+    </Container>
   );
 };
 

--- a/src/components/SimulationResults/SimulationPoints.tsx
+++ b/src/components/SimulationResults/SimulationPoints.tsx
@@ -12,8 +12,13 @@ const SimulationPoints: React.FC<SimulationPointsProps> = ({
 }) => {
   return (
     <Group className="gap-1">
-      <Text component="span">{strategy_name}:</Text>
-      <Text>{strategy_points}</Text>
+      <Text
+        component="span"
+        className="font-bold text-[--mantine-primary-color-9]"
+      >
+        {strategy_name}:
+      </Text>
+      <Text className="font-extralight">{strategy_points}</Text>
     </Group>
   );
 };

--- a/src/components/SimulationResults/SimulationPoints.tsx
+++ b/src/components/SimulationResults/SimulationPoints.tsx
@@ -1,0 +1,21 @@
+import { Group, Text } from "@mantine/core";
+import React from "react";
+
+interface SimulationPointsProps {
+  strategy_name: string;
+  strategy_points: number;
+}
+
+const SimulationPoints: React.FC<SimulationPointsProps> = ({
+  strategy_name,
+  strategy_points,
+}) => {
+  return (
+    <Group className="gap-1">
+      <Text component="span">{strategy_name}:</Text>
+      <Text>{strategy_points}</Text>
+    </Group>
+  );
+};
+
+export default SimulationPoints;

--- a/src/components/SimulationResults/SimulationResults.tsx
+++ b/src/components/SimulationResults/SimulationResults.tsx
@@ -3,6 +3,8 @@ import {
   Center,
   Collapse,
   Container,
+  Group,
+  Stack,
   Table,
   TableData,
   Text,
@@ -11,6 +13,7 @@ import {
 import { useSimulation } from "../../hooks/useSimulation";
 import { useDisclosure } from "@mantine/hooks";
 import { useEffect } from "react";
+import SimulationPoints from "./SimulationPoints";
 
 const SimulationResult = () => {
   const { results } = useSimulation();
@@ -47,14 +50,20 @@ const SimulationResult = () => {
 
   return (
     <Container>
-      <Title>Simulation Results</Title>
-      <h3>Final Score</h3>
-      <p>
-        {results.strategy1}: {results.finalScore.strategy1}
-      </p>
-      <p>
-        {results.strategy2}: {results.finalScore.strategy2}
-      </p>
+      <Title order={2}>Simulation Results</Title>
+      <Title order={3}>Final Score</Title>
+      <Stack className="mb-4">
+        <Group justify="center" wrap="nowrap">
+          <SimulationPoints
+            strategy_name={results.strategy1}
+            strategy_points={results.finalScore.strategy1}
+          />
+          <SimulationPoints
+            strategy_name={results.strategy2}
+            strategy_points={results.finalScore.strategy2}
+          />
+        </Group>
+      </Stack>
       <Center className="mb-2">
         <Button onClick={toggle}>Show rounds</Button>
       </Center>

--- a/src/components/SimulationResults/SimulationResults.tsx
+++ b/src/components/SimulationResults/SimulationResults.tsx
@@ -14,10 +14,12 @@ import { useSimulation } from "../../hooks/useSimulation";
 import { useDisclosure } from "@mantine/hooks";
 import { useEffect } from "react";
 import SimulationPoints from "./SimulationPoints";
+import SimulationWinnerChip from "./SimulationWinnerChip";
 
 const SimulationResult = () => {
   const { results } = useSimulation();
   const [showResultsTable, { toggle, close }] = useDisclosure(false);
+
   useEffect(() => {
     close();
   }, [results]);
@@ -48,12 +50,19 @@ const SimulationResult = () => {
     ]),
   };
 
+  const decideWinner = {
+    strategy1Name: results.strategy1,
+    strategy1Points: results.finalScore.strategy1,
+    strategy2Name: results.strategy2,
+    strategy2Points: results.finalScore.strategy2,
+  };
+
   return (
     <Container>
       <Title order={2}>Simulation Results</Title>
       <Title order={3}>Final Score</Title>
       <Stack className="mb-4">
-        <Group justify="center" wrap="nowrap">
+        <Group justify="center">
           <SimulationPoints
             strategy_name={results.strategy1}
             strategy_points={results.finalScore.strategy1}
@@ -63,6 +72,9 @@ const SimulationResult = () => {
             strategy_points={results.finalScore.strategy2}
           />
         </Group>
+        <Center>
+          <SimulationWinnerChip {...decideWinner} />
+        </Center>
       </Stack>
       <Center className="mb-2">
         <Button onClick={toggle}>Show rounds</Button>

--- a/src/components/SimulationResults/SimulationResults.tsx
+++ b/src/components/SimulationResults/SimulationResults.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   Title,
 } from "@mantine/core";
-import { useSimulation } from "../hooks/useSimulation";
+import { useSimulation } from "../../hooks/useSimulation";
 import { useDisclosure } from "@mantine/hooks";
 import { useEffect } from "react";
 

--- a/src/components/SimulationResults/SimulationWinnerChip.tsx
+++ b/src/components/SimulationResults/SimulationWinnerChip.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface SimulationWinnerChipProps {
+  strategy1Name: string;
+  strategy2Name: string;
+  strategy1Points: number;
+  strategy2Points: number;
+}
+
+const SimulationWinnerChip: React.FC<SimulationWinnerChipProps> = ({
+  strategy1Name,
+  strategy1Points,
+  strategy2Name,
+  strategy2Points,
+}) => {
+  if (strategy1Points === strategy2Points) {
+    return (
+      <p className="bg-[--mantine-primary-color-filled] py-1 px-4 rounded-full text-[--mantine-color-white] text-sm">
+        There is a tie
+      </p>
+    );
+  }
+  return (
+    <>
+      <span className="bg-[--mantine-primary-color-filled] py-1 px-4 rounded-full text-[--mantine-color-white] text-sm">
+        {strategy1Points > strategy2Points ? strategy1Name : strategy2Name} wins
+      </span>
+    </>
+  );
+};
+
+export default SimulationWinnerChip;

--- a/src/components/SimulationResults/index.ts
+++ b/src/components/SimulationResults/index.ts
@@ -1,0 +1,3 @@
+import SimulationResult from "./SimulationResults";
+
+export default SimulationResult;

--- a/src/components/StrategySimulationForm/StrategySimulationForm.tsx
+++ b/src/components/StrategySimulationForm/StrategySimulationForm.tsx
@@ -28,6 +28,7 @@ const StrategySimulationForm = () => {
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     if (strategy1Name && strategy2Name) {
+      setResults(null);
       const results = simulatePlay(strategy1Name, strategy2Name, rounds);
       setResults(results);
     }


### PR DESCRIPTION
#Add styles to Simulation Results
Update Simulation Results components to use Mantine components and Tailwind CSS styles. The list of changes is:
- Use Mantine table to display data
- Add button to collapse the table data
- Create Simulation Points component
  - Displays the points for each strategy, alog with the result
- Create Simulation Winner Chip component
  - Displays the strategy that had more points, or if the match ended in a tie