### PR TITLE
Fix simulation form overflow

### DIFF
--- a/src/components/Section/Section.module.css
+++ b/src/components/Section/Section.module.css
@@ -2,7 +2,4 @@
   min-height: calc(
     100dvh - var(--app-shell-header-offset, 0rem) - var(--app-shell-padding)
   );
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 }

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,11 +1,13 @@
-import { Container } from "@mantine/core";
+import { Stack } from "@mantine/core";
 import React from "react";
 import classes from "./Section.module.css";
 
 const Section: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
-    <section className={classes.Section}>
-      <Container>{children}</Container>
+    <section>
+      <Stack justify="center" className={classes.Section}>
+        {children}
+      </Stack>
     </section>
   );
 };

--- a/src/components/SimulationResults/SimulationResults.tsx
+++ b/src/components/SimulationResults/SimulationResults.tsx
@@ -10,9 +10,9 @@ import {
   Text,
   Title,
 } from "@mantine/core";
-import { useSimulation } from "../../hooks/useSimulation";
 import { useDisclosure } from "@mantine/hooks";
 import { useEffect } from "react";
+import { useSimulation } from "../../hooks/useSimulation";
 import SimulationPoints from "./SimulationPoints";
 import SimulationWinnerChip from "./SimulationWinnerChip";
 
@@ -80,6 +80,7 @@ const SimulationResult = () => {
         <Button onClick={toggle}>Show rounds</Button>
       </Center>
       <Collapse in={showResultsTable} transitionDuration={500} className="mb-4">
+        <Table.ScrollContainer minWidth={200}>
         <Table
           striped="even"
           data={tableData}
@@ -92,7 +93,8 @@ const SimulationResult = () => {
             td: "text-center",
             thead: "bg-[--table-striped-color]",
           }}
-        />
+          />
+          </Table.ScrollContainer>
       </Collapse>
     </Container>
   );


### PR DESCRIPTION
# Fix overflow when resuls table opened

Add Mantine Table.ScrollContainer wrapper to Table component, and simplify Section component to add scroll behaviour to table instead of overflow
